### PR TITLE
Add option to define systemd WorkingDirectory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@ class traefik2 (
   Enum['running','stopped'] $service_ensure,
   Hash $static_config,
   String[1] $version,
+
+  Optional[Stdlib::Absolutepath] $systemd_workdir = undef
 ) {
   anchor { 'traefik2::begin': }
 -> class{ '::traefik2::install': }

--- a/templates/traefik2.service.epp
+++ b/templates/traefik2.service.epp
@@ -9,6 +9,9 @@ Type=simple
 ExecStart=<%= $traefik2::bin_dir %>/traefik --configFile=<%= $traefik2::config_dir %>/config.yaml
 Restart=on-failure
 RestartSec=30s
+<% if $traefik2::systemd_workdir != undef { -%>
+WorkingDirectory=<%= $traefik2::systemd_workdir %>
+<% } -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Traefik has a feature to use local plugins since version 2.5.0. These plugins get loaded from the directory where the process is started. When using systemd, that's / by default. Installing plugins there doesn't seem like the best fit.

You can define WorkingDirectory in a systemd service file. This PR allows you to define a custom WorkingDirectory, so you can install the local plugins wherever you'd like.