### PR TITLE
Patch - Set working directory for service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,6 +11,7 @@ class traefik2::service {
         ::systemd::unit_file { "${traefik2::service_name}.service":
           content => epp('traefik2/traefik2.service.epp'),
           before  => Service['traefik2'],
+          notify  => Service['traefik2'],
         }
       }
       default: {

--- a/templates/traefik2.service.epp
+++ b/templates/traefik2.service.epp
@@ -6,6 +6,7 @@ After=basic.target network.target
 
 [Service]
 Type=simple
+WorkingDirectory=<%= $traefik2::data_dir %>
 ExecStart=<%= $traefik2::bin_dir %>/traefik --configFile=<%= $traefik2::config_dir %>/config.yaml
 Restart=on-failure
 RestartSec=30s


### PR DESCRIPTION
Set the working directory for the service so the plugins-storage directory does not end up in root.