### PR TITLE
feat: run traefik as unprivileged user and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # attachmentgenie-traefik2
 
+> [!NOTE]
+> This is a security-hardened fork of the original [attachmentgenie/puppet-traefik2](https://github.com/attachmentgenie/attachmentgenie-traefik2) module. All credit for the baseline codebase goes to the original author, attachmentgenie.
+
 [![](https://img.shields.io/puppetforge/pdk-version/attachmentgenie/traefik2.svg?style=popout)](https://forge.puppetlabs.com/attachmentgenie/traefik2)
 [![](https://img.shields.io/puppetforge/v/attachmentgenie/traefik2.svg?style=popout)](https://forge.puppetlabs.com/attachmentgenie/traefik2)
 [![](https://img.shields.io/puppetforge/dt/attachmentgenie/traefik2.svg?style=popout)](https://forge.puppetlabs.com/attachmentgenie/traefik2)
@@ -30,6 +33,22 @@ You can view example usage in [REFERENCE](REFERENCE.md).
 ## Reference
 
 See [REFERENCE](REFERENCE.md).
+
+## Hardening & De-rooting (Fork Enhancements)
+
+This fork contains critical security enhancements to run Traefik as a secure, unprivileged system user instead of `root`.
+
+### Features
+* **Unprivileged Execution:** The Traefik process runs under a dedicated `traefik` user and group.
+* **Privileged Ports:** Ambient capabilities (`CAP_NET_BIND_SERVICE`) are assigned to the systemd service unit. This allows the unprivileged Traefik process to bind directly to standard web ports (80 and 443) without root access.
+* **Configuration Security:** Configuration files are restricted with `0640` permissions, ensuring only the `traefik` process and root can read them.
+
+### New Class Parameters
+You can configure the user and group settings via the main `traefik2` class:
+
+* `user`: The system user name (default: `'traefik'`).
+* `group`: The system group name (default: `'traefik'`).
+* `manage_user`: Boolean to control whether the module creates the system user and group account (default: `true`).
 
 ## Limitations
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,13 +7,21 @@
 class traefik2::config {
   file { $traefik2::config_dir:
     ensure => directory,
+    owner  => $traefik2::user,
+    group  => $traefik2::group,
   }
   -> file { 'traefik static config':
     path    => "${traefik2::config_dir}/config.yaml",
+    owner   => $traefik2::user,
+    group   => $traefik2::group,
+    mode    => '0640',
     content => inline_epp('<%= $config.to_yaml %>', { 'config' => $traefik2::static_config }),
   }
   -> file { 'traefik dynamic_config':
     path    => "${traefik2::config_dir}/dynamic.yaml",
+    owner   => $traefik2::user,
+    group   => $traefik2::group,
+    mode    => '0640',
     content => inline_epp('<%= $config.to_yaml %>', { 'config' => $traefik2::dynamic_config }),
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,4 @@
-# @summary A short summary of the purpose of this class
-#
-# A description of what this class does
+# @summary Install, configure, and run Traefik as a confined edge proxy.
 #
 # @example
 #   include traefik2
@@ -19,8 +17,21 @@ class traefik2 (
   Hash $static_config,
   String[1] $version,
 
+  # De-root: run as a dedicated, unprivileged system user instead of
+  # root. AmbientCapabilities=CAP_NET_BIND_SERVICE on the systemd unit
+  # lets it still bind :80/:443 without root. Set manage_user => false
+  # if the user/group already exist (e.g. managed elsewhere).
+  String[1] $user           = 'traefik',
+  String[1] $group          = 'traefik',
+  Boolean   $manage_user    = true,
+
   Optional[Stdlib::Absolutepath] $systemd_workdir = undef
 ) {
+  if $manage_user {
+    contain 'traefik2::user'
+    Class['traefik2::user'] -> Class['traefik2::install']
+  }
+
   contain 'traefik2::install'
   contain 'traefik2::config'
   contain 'traefik2::service'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,8 @@ class traefik2::install {
 
       file { [$traefik2::data_dir, $version_dir]:
         ensure => directory,
+        owner  => $traefik2::user,
+        group  => $traefik2::group,
       }
       -> archive { "${binary_path}.tar.gz":
         ensure       => present,

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,17 @@
+# @summary Dedicated system account Traefik runs as (de-root).
+class traefik2::user {
+  group { $traefik2::group:
+    ensure => present,
+    system => true,
+  }
+
+  user { $traefik2::user:
+    ensure     => present,
+    system     => true,
+    gid        => $traefik2::group,
+    shell      => '/usr/sbin/nologin',
+    home       => $traefik2::data_dir,
+    managehome => false,
+    require    => Group[$traefik2::group],
+  }
+}

--- a/spec/classes/user_spec.rb
+++ b/spec/classes/user_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'traefik2::user' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:pre_condition) do
+        <<-EOF
+        class traefik2 {
+          $user     = 'traefik'
+          $group    = 'traefik'
+          $data_dir = '/var/lib/traefik2'
+        }
+        include traefik2
+        EOF
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_group('traefik').with(
+        'ensure' => 'present',
+        'system' => true,
+      )}
+      it { is_expected.to contain_user('traefik').with(
+        'ensure'     => 'present',
+        'system'     => true,
+        'gid'        => 'traefik',
+        'shell'      => '/usr/sbin/nologin',
+        'managehome' => false,
+      )}
+    end
+  end
+end

--- a/templates/traefik2.service.epp
+++ b/templates/traefik2.service.epp
@@ -6,6 +6,11 @@ After=basic.target network.target
 
 [Service]
 Type=simple
+User=<%= $traefik2::user %>
+Group=<%= $traefik2::group %>
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
 WorkingDirectory=<%= $traefik2::data_dir %>
 ExecStart=<%= $traefik2::bin_dir %>/traefik --configFile=<%= $traefik2::config_dir %>/config.yaml
 Restart=on-failure


### PR DESCRIPTION
This PR adds support for running Traefik under a dedicated, unprivileged system user (defaults to `traefik`). I used systemd's `AmbientCapabilities=CAP_NET_BIND_SERVICE` in the service template so it can still bind to ports 80 and 443 without needing root privileges.
Summary of changes:
- Adds `user`, `group`, and `manage_user` parameters to the main class.
- Restricts configuration file permissions to `0640` (owned by the traefik user).
- Adds a `user.pp` class to handle system user/group creation.
- Includes a basic rspec-puppet test (`user_spec.rb`) to verify the user setup.
This has been tested locally and compiles/runs cleanly. Let me know what you think!
